### PR TITLE
simple fix for multiple calls to do{Raw}Request

### DIFF
--- a/bsdapi/BsdApi.py
+++ b/bsdapi/BsdApi.py
@@ -50,7 +50,7 @@ class BsdApi:
         url_secure = self._generateRequest('/get_deferred_results', query)
         return self._makeGETRequest(url_secure)
 
-    def doRequest(self, api_call, api_params = {}, request_type = GET, body = None, headers = None, https = False):
+    def doRequest(self, api_call, api_params = None, request_type = GET, body = None, headers = None, https = False):
         url = self._generateRequest(api_call, api_params, https)
 
         if request_type == "GET":
@@ -58,7 +58,7 @@ class BsdApi:
         else:
             return self._makePOSTRequest(url, body, https)
 
-    def doRawRequest(self, api_call, api_params = {}, request_type = GET, body = None, headers = None, https = False):
+    def doRawRequest(self, api_call, api_params = None, request_type = GET, body = None, headers = None, https = False):
         url = self._generateRequest(api_call, api_params, https)
         return self._makeRequest(url, request_type, body, headers, https);
 


### PR DESCRIPTION
The dictionary passed as a default parameter in each of these functions was being filled in with default values in RequestGenerator.getUrl(). This included the timestamp, which would result in an error on the server side (403) if too much time had passed since the initial call.

The code seems to generally handle None for api_params, so the simple fix was to make that the default value.
